### PR TITLE
Tell vox to use the entire pipenv path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='xontrib-apipenv',
-    version='0.5.0',
+    version='0.6.0',
     url='https://github.com/greg-hellings/xonsh-apipenv',
     license='MIT',
     author='Greg Hellings',

--- a/xontrib/xonsh-apipenv.xsh
+++ b/xontrib/xonsh-apipenv.xsh
@@ -42,7 +42,7 @@ class PipenvActivator():
 
             self.pipenv_proj_path = pathlib.Path(project.pipfile_location).parent
 
-            vox activate @(venv_name)
+            vox activate @(venv_path)
 
 
 _pa = PipenvActivator()


### PR DESCRIPTION
Rather than re-use the pipenv name, only, and have it end up wherever vox keeps its paths, use the full path to the pipenv virtualenv